### PR TITLE
fix: DMOV07 returns TypeInputIo instead of TypeMovIo

### DIFF
--- a/custom_components/domintell/domintell_api/lightprotocol.py
+++ b/custom_components/domintell/domintell_api/lightprotocol.py
@@ -1257,8 +1257,8 @@ class LpAppInfo:
         io_type = int(io_type_str)
 
         # Fixed a bug in older versions of LP
-        # For DMOV06 appinfo return TypeInputIo instead of TypeMovIo
-        if module_type == "MV6" and io_type == 2:
+        # For DMOV06 and DMOV07 appinfo return TypeInputIo instead of TypeMovIo
+        if module_type in ("MV6", "MV7") and io_type == 2:
             io_type_str = "34"  # TypeMovIo
             io_type = int(io_type_str)
 


### PR DESCRIPTION
First of all - thank you for the official integration!

Second - my DMOV07 also returns `TypeInputIo` instead of `TypeMovIo`. Maybe something wrong with my DMOV07, not sure.

```
result: {'id': 'MV70000CA-2-1', 'module_type': 'MV7', 'serial_number': '650000CA', 'io_type': 2, 'io_offset': 1, 'io_name': 'XXX', 'sw_version': '0.0.0', 'installation_name': 'XXX', 'floor_name': 'XXX', 'room_name': '', 'extra_info': ['1'], 'target_type': 'button'}
result: {'id': 'MV70000CA-36-1', 'module_type': 'MV7', 'serial_number': '650000CA', 'io_type': 36, 'io_offset': 1, 'io_name': 'XXX', 'sw_version': '5', 'installation_name': 'XXX', 'floor_name': 'XXX', 'room_name': '', 'extra_info': None, 'target_type': 'illuminance'}
```

This was causing errors like


```
2025-08-13 13:04:11.286 WARNING (MainThread) [custom_components.domintell.domintell_api[192.168.3.21]] Motion controller received update for unknown io MV70000CD-34-1
2025-08-13 13:04:11.888 WARNING (MainThread) [custom_components.domintell.domintell_api[192.168.3.21]] Motion controller received update for unknown io MV70000CD-34-1
2025-08-13 13:04:12.195 WARNING (MainThread) [custom_components.domintell.domintell_api[192.168.3.21]] Motion controller received update for unknown io MV70000CD-34-1
```

Found in the codebase that there is a workaround for MV6, so added the same workaround for MV7.